### PR TITLE
feat(language-menu): create language menu page

### DIFF
--- a/src/app/(pages)/flashcards/[id]/create/page.tsx
+++ b/src/app/(pages)/flashcards/[id]/create/page.tsx
@@ -3,21 +3,27 @@ import Title from "@/components/ui/Title";
 import { getLanguageName } from "@/utils/getLanguage";
 import Image from "next/image";
 
-export default async function FlashcardPage({ params }: { params: { id: string } }) {
+export default async function FlashcardPage({
+  params,
+}: {
+  params: { id: string };
+}) {
   const { id } = await params;
   const language = getLanguageName(id);
 
   if (!id || !language) return <div>No language found</div>;
 
   return (
-    <div className="flex flex-col gap-6 items-center justify-center">
-      <Title>Créer une flashcard en {language}</Title>
-      <Image
-        src={`/assets/flags/${id}.png`}
-        alt={`Drapeau de ${language}`}
-        width={100}
-        height={100}
-      />
+    <div className="flex flex-col gap-8 items-center justify-center">
+      <div className="flex gap-6 w-full">
+        <Image
+          src={`/assets/flags/${id}.png`}
+          alt={`Drapeau de ${language}`}
+          width={40}
+          height={40}
+        />
+        <Title>Yeah un nouveau mot !</Title>
+      </div>
       <div className="w-full flex justify-center">
         <FlashcardForm languageCode={id} />
       </div>

--- a/src/app/(pages)/flashcards/[id]/page.tsx
+++ b/src/app/(pages)/flashcards/[id]/page.tsx
@@ -1,0 +1,22 @@
+import Button from "@/components/ui/Button";
+import Title from "@/components/ui/Title";
+import Link from "next/link";
+
+export default async function ManageFlashcards({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { id } = await params;
+
+  if (!id) return <div>No language found</div>;
+
+  return (
+    <div className="flex flex-col gap-8 items-center justify-center">
+      <Title>Gérer les flashcards</Title>
+      <Link href={`/flashcards/${id}/create`}>
+        <Button className="create-button">Créer une flashcard</Button>
+      </Link>
+    </div>
+  );
+}

--- a/src/app/(pages)/language/[id]/page.tsx
+++ b/src/app/(pages)/language/[id]/page.tsx
@@ -1,36 +1,63 @@
 import Button from "@/components/ui/Button";
 import Title from "@/components/ui/Title";
 import { getLanguageName } from "@/utils/getLanguage";
+import { ArrowBigRight, BicepsFlexed, Dumbbell, Lightbulb } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 
-export default async function LanguageMenu({ params }: { params: { id: string } }) {
+export default async function LanguageMenu({
+  params,
+}: {
+  params: { id: string };
+}) {
   const { id } = await params;
   const language = getLanguageName(id);
-  
+
   if (!id || !language) return <div>No language found</div>;
 
   return (
-    <div className="flex flex-col gap-4 items-center justify-center">
-      <Title>Liste des actions pour la langue : {language}</Title>
-      <Image
-        src={`/assets/flags/${id}.png`}
-        alt={`Drapeau de ${language}`}
-        width={100}
-        height={100}
-      />
-      <ul className="flex gap-4">
+    <div className="flex flex-col gap-20 items-center justify-center">
+      <div className="flex justify-center gap-6 w-full">
+        <Image
+          src={`/assets/flags/${id}.png`}
+          alt={`Drapeau de ${language}`}
+          width={40}
+          height={40}
+        />
+        <Title>Hey! Prêt à travailler ton {language} ?</Title>
+      </div>
+      <ul className="flex gap-8">
         <li>
-          <Link href={`/flashcards/create/${id}`}>
-            <Button>Create Flashcards</Button>
+          <Link href={`/flashcards/${id}/create`}>
+            <Button variant="icon" className="create-color">
+              <Lightbulb size={64} color={"#FFD5A6"} />
+              <span className="font-bold">Mode Création</span>
+            </Button>
           </Link>
         </li>
         <li>
-          <Link href={`/flashcards/${id}`}>
-            <Button>All Flashcards</Button>
+          <Link href={`/language/${id}/train/`}>
+            <Button variant="icon" className="train-color">
+              <Dumbbell size={64} color={"#BFDBFF"} />
+              <span className="font-bold">Mode Entraînement</span>
+            </Button>
+          </Link>
+        </li>
+        <li>
+          <Link href={`/language/${id}/test`}>
+            <Button variant="icon" className="test-color">
+              <BicepsFlexed size={64} color={"#FFCCD3"} />
+              <span className="font-bold">Mode Révision</span>
+            </Button>
           </Link>
         </li>
       </ul>
+      <Link href={`/flashcards/${id}`}>
+        <Button className="flex items-center gap-2">
+          <ArrowBigRight />
+          <p>Gérer les flashcards</p>
+        </Button>
+      </Link>
     </div>
   );
 }

--- a/src/app/(pages)/language/[id]/test/page.tsx
+++ b/src/app/(pages)/language/[id]/test/page.tsx
@@ -1,0 +1,7 @@
+export default function TestPage() {
+  return (
+    <div>
+      <h1>Test your vocabulary</h1>
+    </div>
+  );
+}

--- a/src/app/(pages)/language/[id]/train/page.tsx
+++ b/src/app/(pages)/language/[id]/train/page.tsx
@@ -1,0 +1,7 @@
+export default function TrainPage() {
+  return (
+    <div>
+      <h1>Train your vocabulary</h1>
+    </div>
+  );
+}

--- a/src/app/(pages)/languages/page.tsx
+++ b/src/app/(pages)/languages/page.tsx
@@ -18,7 +18,7 @@ const getHref = (langCode: string, user: IUser | null): string => {
   if (user && hasFlashcardsOfLanguage(langCode, user)) {
     return `/language/${langCode.toLowerCase()}`;
   }
-  return `/flashcards/create/${langCode.toLowerCase()}`
+  return `/flashcards/${langCode.toLowerCase()}/create`;
 };
 
 export default function LanguagesPage({ user }: { user: IUser | null }) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,3 +26,15 @@
 img {
   @apply w-auto object-contain;
 }
+
+.create-color {
+  @apply   border-orange-300 bg-orange-300 hover:text-orange-300 hover:bg-transparent ;
+}
+
+.train-color {
+  @apply border-blue-300 bg-blue-300 hover:text-blue-300 hover:bg-transparent ;
+}
+
+.test-color {
+  @apply border-rose-300 bg-rose-300 hover:text-rose-300 hover:bg-transparent ;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default async function RootLayout({
             <header className="p-4">
               <Header />
             </header>
-            <main className="flex-1 flex items-center justify-center overflow-auto">
+            <main className="flex-1 flex items-center justify-center p-4">
               {children}
             </main>
             <footer className="flex justify-center bottom-0">

--- a/src/components/pages/flashcard/FlashcardForm.tsx
+++ b/src/components/pages/flashcard/FlashcardForm.tsx
@@ -31,17 +31,17 @@ const FlashcardForm = ({ languageCode }: { languageCode: string }) => {
 
   return (
     <div className="bg-white p-8 rounded-3xl shadow-lg flex flex-col gap-6 items-center shadow-blue-200 w-full max-w-sm sm:max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl">
-      <Title variant="flashcard">Créer votre flashcard</Title>
+      <Title variant="flashcard">Crée ta flashcard</Title>
       <div className="flex flex-col items-center gap-6 w-full">
         {/* // TODO : add the natif language of the user and the language that the
         user wants to learn */}
         <Input
-          placeholder="Mot dans votre langue"
+          placeholder="Mot dans ta langue"
           value={nativeWord}
           onChange={setNativeWord}
         />
         <Input
-          placeholder="Mot traduit"
+          placeholder="Mot traduit dans la langue cible"
           value={translatedWord}
           onChange={setTranslatedWord}
         />

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,5 +1,5 @@
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: "auth" | "primary" | "submit" | "option";
+  variant?: "auth" | "primary" | "submit" | "option" | "icon";
   className?: string;
 };
 
@@ -12,11 +12,12 @@ const Button = ({
   const baseStyle = "p-2 cursor-pointer";
 
   const variants = {
-    auth: "border-2 uppercase text-sm w-38 rounded-md",
-    primary: "border-2 uppercase rounded-xl",
+    auth: "border-2 uppercase text-sm w-38 rounded-md hover:bg-black hover:text-white",
+    primary: "border-2 uppercase rounded-xl hover:bg-emerald-200",
     submit:
       "border-1 bg-emerald-200 w-full uppercase rounded-xl hover:bg-emerald-300 ",
     option: "flex justify-center gap-2",
+    icon: "border-2 rounded-xl flex flex-col items-center gap-12 min-w-60 p-8 text-white",
   };
 
   return (

--- a/src/data/languages.ts
+++ b/src/data/languages.ts
@@ -1,10 +1,10 @@
 export const languages = [
   { code: "FR", name: "Français", flagUrl: "/assets/flags/fr.png" },
-  { code: "EN", name: "English", flagUrl: "/assets/flags/en.png" },
-  { code: "ES", name: "Español", flagUrl: "/assets/flags/es.png" },
-  { code: "DE", name: "Deutsch", flagUrl: "/assets/flags/de.png" },
-  { code: "IT", name: "Italiano", flagUrl: "/assets/flags/it.png" },
-  { code: "PT", name: "Português", flagUrl: "/assets/flags/pt.png" },
+  { code: "EN", name: "Anglais", flagUrl: "/assets/flags/en.png" },
+  { code: "ES", name: "Espagnol", flagUrl: "/assets/flags/es.png" },
+  { code: "DE", name: "Allemand", flagUrl: "/assets/flags/de.png" },
+  { code: "IT", name: "Italien", flagUrl: "/assets/flags/it.png" },
+  { code: "PT", name: "Portugais", flagUrl: "/assets/flags/pt.png" },
 ];
 
 export const categories = [


### PR DESCRIPTION
## Description
- Create a language menu page with buttons to redirect to flashcards creation, management, train or test pages
- Create new button variant to use icons
- Add new color classes
- Create basic pages for train, test and manages flashcards
- fix some minor style and wording issues

Display of the page:

<img width="1464" height="749" alt="image" src="https://github.com/user-attachments/assets/64397a36-a629-4428-bc66-1e66c9efb620" />
