### PR TITLE
feat(train-flashcards): create train page and hook for flashcard logic

### DIFF
--- a/src/app/(pages)/language/[id]/train/page.tsx
+++ b/src/app/(pages)/language/[id]/train/page.tsx
@@ -1,7 +1,64 @@
-export default function TrainPage() {
+"use client";
+import React, { useEffect, useState } from "react";
+import { getLanguageName } from "@/utils/language";
+import { Title } from "@/ui";
+import { TFlashcard } from "@/types/flashcard";
+import Flashcard from "@/components/card/Flashcard";
+
+export default function TrainPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = React.use(params);
+  const language = getLanguageName(id);
+
+  const [flashcards, setFlashcards] = useState<TFlashcard[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadUserFlashcards() {
+      try {
+        const res = await fetch("/api/flashcards");
+        if (!res.ok)
+          throw new Error("Erreur lors du chargement des flashcards");
+        const data = await res.json();
+
+        const filtered = data.flashcards.filter(
+          (fc: TFlashcard) => fc.targetLanguages === id
+        );
+
+        setFlashcards(filtered);
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadUserFlashcards();
+  }, [id]);
+
+  if (loading) return <p>Chargement...</p>;
+  if (error) return <p>Erreur : {error}</p>;
+  if (flashcards.length === 0)
+    return <p>Aucune flashcard trouvée pour la langue {language}.</p>;
+
   return (
-    <div>
-      <h1>Train your vocabulary</h1>
+    <div className="flex flex-col items-center gap-6">
+      <Title variant="sm">
+        Entraînement en {language.toLowerCase()} — carte {currentIndex + 1} /{" "}
+        {flashcards.length}
+      </Title>
+
+      <Flashcard
+        setCurrentIndex={setCurrentIndex}
+        currentIndex={currentIndex}
+        flashcards={flashcards}
+      />
     </div>
   );
 }

--- a/src/app/(pages)/language/[id]/train/page.tsx
+++ b/src/app/(pages)/language/[id]/train/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { getLanguageName } from "@/utils/language";
-import { Title } from "@/ui";
+import { LinkButton, Title } from "@/ui";
 import { TFlashcard } from "@/types/flashcard";
 import Flashcard from "@/components/card/Flashcard";
 
@@ -57,7 +57,7 @@ export default function TrainPage({
         language={language}
         id={id}
       />
-      <div className="flex gap-12">
+      <div className="flex gap-12 mb-10">
         <p>
           Carte n° {""}
           <span className="font-bold">{currentIndex + 1}</span>
@@ -67,6 +67,10 @@ export default function TrainPage({
           <span className="font-bold">{flashcards.length}</span>
         </p>
       </div>
+      <LinkButton
+        href={`/language/${id}`}
+        text="Retour vers la page principale"
+      />
     </div>
   );
 }

--- a/src/app/(pages)/language/[id]/train/page.tsx
+++ b/src/app/(pages)/language/[id]/train/page.tsx
@@ -48,17 +48,25 @@ export default function TrainPage({
     return <p>Aucune flashcard trouvée pour la langue {language}.</p>;
 
   return (
-    <div className="flex flex-col items-center gap-6">
-      <Title variant="sm">
-        Entraînement en {language.toLowerCase()} — carte {currentIndex + 1} /{" "}
-        {flashcards.length}
-      </Title>
-
+    <div className="flex flex-col items-center gap-6 w-[900px]">
+      <Title variant="md">Entraînement en {language.toLowerCase()}</Title>
       <Flashcard
         setCurrentIndex={setCurrentIndex}
         currentIndex={currentIndex}
         flashcards={flashcards}
+        language={language}
+        id={id}
       />
+      <div className="flex gap-12">
+        <p>
+          Carte n° {""}
+          <span className="font-bold">{currentIndex + 1}</span>
+        </p>
+        <p>
+          Nombre de cartes restantes :{" "}
+          <span className="font-bold">{flashcards.length}</span>
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/components/card/Flashcard.tsx
+++ b/src/components/card/Flashcard.tsx
@@ -1,0 +1,85 @@
+import { Button, Input } from "@/ui";
+import { useFlashcardSession } from "@/hooks/useFlashcardSession";
+import { TFlashcard } from "@/types/flashcard";
+
+type FlashcardProps = {
+  currentIndex: number;
+  setCurrentIndex: React.Dispatch<React.SetStateAction<number>>;
+  flashcards: TFlashcard[];
+};
+
+export default function Flashcard({
+  currentIndex,
+  setCurrentIndex,
+  flashcards,
+}: FlashcardProps) {
+  const {
+    currentCard,
+    answer,
+    state,
+    handleAnswer,
+    handleCheckAnswer,
+    handleHelp,
+    handleNext,
+    handleReloadInput,
+  } = useFlashcardSession(flashcards, currentIndex, setCurrentIndex);
+
+  const buttonsConfig = [
+    {
+      states: ["answering"],
+      label: "Vérifier",
+      onClick: handleCheckAnswer,
+    },
+    { states: ["answering"], label: "Voir la réponse", onClick: handleHelp },
+    { states: ["incorrect"], label: "Réessayer", onClick: handleReloadInput },
+    {
+      states: ["correct", "help-shown"],
+      label: "Carte suivante",
+      onClick: handleNext,
+    },
+  ];
+
+  const renderedButtons = buttonsConfig
+    .filter((b) => b.states.includes(state))
+    .map((b) => (
+      <Button key={b.label} onClick={b.onClick}>
+        {b.label}
+      </Button>
+    ));
+
+  return (
+    <div className="bg-white p-8 rounded-3xl shadow-lg flex flex-col gap-6 justify-between text-center w-full max-w-md h-[300px]">
+      <p className="text-xl font-semibold">
+        Mot à traduire : <strong>{currentCard.nativeWord}</strong>
+      </p>
+
+      {state === "correct" && (
+        <p className="text-green-600">
+          🎉 Bravo ! La bonne réponse était :{" "}
+          <strong>{currentCard.translatedWord}</strong>
+        </p>
+      )}
+
+      {state === "help-shown" && (
+        <p className="text-green-600">
+          La réponse est : <strong>{currentCard.translatedWord}</strong>
+        </p>
+      )}
+
+      <>
+        {state === "answering" && (
+          <Input
+            placeholder="Écris la traduction ici"
+            value={answer}
+            onChange={handleAnswer}
+          />
+        )}
+
+        {state === "incorrect" && (
+          <p className="text-red-500">❌ Mauvaise réponse, réessaie !</p>
+        )}
+      </>
+      <div className="flex gap-16 justify-center w-full">{renderedButtons}</div>
+    </div>
+  );
+}

--- a/src/components/card/Flashcard.tsx
+++ b/src/components/card/Flashcard.tsx
@@ -2,11 +2,15 @@ import { Button, Input } from "@/ui";
 import { useFlashcardSession } from "@/hooks/useFlashcardSession";
 import { TFlashcard } from "@/types/flashcard";
 import { ButtonProps } from "../ui/Button";
+import { FeedbackMessage } from "./FlashcardMessage";
+import Image from "next/image";
 
 type FlashcardProps = {
   currentIndex: number;
   setCurrentIndex: React.Dispatch<React.SetStateAction<number>>;
   flashcards: TFlashcard[];
+  language: string;
+  id: string;
 };
 
 type ButtonConfig = {
@@ -20,6 +24,8 @@ export default function Flashcard({
   currentIndex,
   setCurrentIndex,
   flashcards,
+  language,
+  id,
 }: FlashcardProps) {
   const {
     currentCard,
@@ -77,25 +83,19 @@ export default function Flashcard({
     });
 
   return (
-    <div className="bg-white p-8 rounded-3xl shadow-lg flex flex-col gap-6 justify-between text-center w-full max-w-md h-[300px]">
+    <div className="bg-white p-8 rounded-3xl shadow-lg flex flex-col justify-between text-center w-full max-w-md h-[300px]">
       <p className="text-xl font-semibold">
         Mot à traduire : <strong>{currentCard.nativeWord}</strong>
       </p>
-
-      {state === "correct" && (
-        <p className="text-green-600">
-          🎉 Bravo ! La bonne réponse était :{" "}
-          <strong>{currentCard.translatedWord}</strong>
-        </p>
-      )}
-
-      {state === "help-shown" && (
-        <p className="text-green-600">
-          La réponse est : <strong>{currentCard.translatedWord}</strong>
-        </p>
-      )}
-
-      <>
+      <div className="flex items-center justify-center gap-4">
+        {state === "answering" && (
+          <Image
+            src={`/assets/flags/${id}.png`}
+            alt={`Drapeau de ${language}`}
+            width={30}
+            height={30}
+          />
+        )}
         {state === "answering" && (
           <Input
             placeholder="Écris la traduction ici"
@@ -103,13 +103,11 @@ export default function Flashcard({
             onChange={handleAnswer}
           />
         )}
-
-        {state === "incorrect" && (
-          <p className="text-red-500">
-            ❌ Ce n'est pas la bonne réponse, réessaie !
-          </p>
-        )}
-      </>
+        <FeedbackMessage
+          state={state}
+          translatedWord={currentCard.translatedWord}
+        />
+      </div>
       <div className="flex gap-4 justify-center w-full">{renderedButtons}</div>
     </div>
   );

--- a/src/components/card/Flashcard.tsx
+++ b/src/components/card/Flashcard.tsx
@@ -94,19 +94,19 @@ export default function Flashcard({
       </p>
       <div className="flex items-center justify-center gap-4">
         {state === "answering" && (
-          <Image
-            src={`/assets/flags/${id}.png`}
-            alt={`Drapeau de ${language}`}
-            width={30}
-            height={30}
-          />
-        )}
-        {state === "answering" && (
-          <Input
-            placeholder="Écris la traduction ici"
-            value={answer}
-            onChange={handleAnswer}
-          />
+          <>
+            <Image
+              src={`/assets/flags/${id}.png`}
+              alt={`Drapeau de ${language}`}
+              width={30}
+              height={30}
+            />
+            <Input
+              placeholder="Écris la traduction ici"
+              value={answer}
+              onChange={handleAnswer}
+            />
+          </>
         )}
         <FeedbackMessage
           state={state}

--- a/src/components/card/Flashcard.tsx
+++ b/src/components/card/Flashcard.tsx
@@ -36,7 +36,8 @@ export default function Flashcard({
     handleHelp,
     handleNext,
     handleReloadInput,
-  } = useFlashcardSession(flashcards, currentIndex, setCurrentIndex);
+    handleFinish,
+  } = useFlashcardSession(flashcards, currentIndex, setCurrentIndex, id);
 
   const buttonsConfig: ButtonConfig[] = [
     {
@@ -59,9 +60,13 @@ export default function Flashcard({
     },
     {
       states: ["correct", "help-shown"],
-      label: "Passer à la flashcard suivante",
+      label:
+        currentIndex === flashcards.length - 1
+          ? "Terminer la session"
+          : "Passer à la flashcard suivante",
       variant: "submit",
-      onClick: handleNext,
+      onClick:
+        currentIndex === flashcards.length - 1 ? handleFinish : handleNext,
     },
   ];
 

--- a/src/components/card/Flashcard.tsx
+++ b/src/components/card/Flashcard.tsx
@@ -1,11 +1,19 @@
 import { Button, Input } from "@/ui";
 import { useFlashcardSession } from "@/hooks/useFlashcardSession";
 import { TFlashcard } from "@/types/flashcard";
+import { ButtonProps } from "../ui/Button";
 
 type FlashcardProps = {
   currentIndex: number;
   setCurrentIndex: React.Dispatch<React.SetStateAction<number>>;
   flashcards: TFlashcard[];
+};
+
+type ButtonConfig = {
+  states: string[];
+  label: string;
+  onClick: () => void;
+  variant?: ButtonProps["variant"];
 };
 
 export default function Flashcard({
@@ -24,28 +32,49 @@ export default function Flashcard({
     handleReloadInput,
   } = useFlashcardSession(flashcards, currentIndex, setCurrentIndex);
 
-  const buttonsConfig = [
+  const buttonsConfig: ButtonConfig[] = [
     {
       states: ["answering"],
-      label: "Vérifier",
+      label: "Vérifier la réponse",
+      variant: "submit",
       onClick: handleCheckAnswer,
     },
-    { states: ["answering"], label: "Voir la réponse", onClick: handleHelp },
-    { states: ["incorrect"], label: "Réessayer", onClick: handleReloadInput },
+    {
+      states: ["answering"],
+      label: "Voir la réponse",
+      variant: "flashcardSeeAnswer",
+      onClick: handleHelp,
+    },
+    {
+      states: ["incorrect"],
+      label: "Je retente ma chance",
+      variant: "flashcardRetryAnwser",
+      onClick: handleReloadInput,
+    },
     {
       states: ["correct", "help-shown"],
-      label: "Carte suivante",
+      label: "Passer à la flashcard suivante",
+      variant: "submit",
       onClick: handleNext,
     },
   ];
 
   const renderedButtons = buttonsConfig
     .filter((b) => b.states.includes(state))
-    .map((b) => (
-      <Button key={b.label} onClick={b.onClick}>
-        {b.label}
-      </Button>
-    ));
+    .map((b) => {
+      const isDisabled = b.label === "Vérifier la réponse" && !answer.trim();
+
+      return (
+        <Button
+          key={b.label}
+          onClick={b.onClick}
+          disabled={isDisabled}
+          variant={b.variant}
+        >
+          {b.label}
+        </Button>
+      );
+    });
 
   return (
     <div className="bg-white p-8 rounded-3xl shadow-lg flex flex-col gap-6 justify-between text-center w-full max-w-md h-[300px]">
@@ -76,10 +105,12 @@ export default function Flashcard({
         )}
 
         {state === "incorrect" && (
-          <p className="text-red-500">❌ Mauvaise réponse, réessaie !</p>
+          <p className="text-red-500">
+            ❌ Ce n'est pas la bonne réponse, réessaie !
+          </p>
         )}
       </>
-      <div className="flex gap-16 justify-center w-full">{renderedButtons}</div>
+      <div className="flex gap-4 justify-center w-full">{renderedButtons}</div>
     </div>
   );
 }

--- a/src/components/card/FlashcardMessage.tsx
+++ b/src/components/card/FlashcardMessage.tsx
@@ -1,0 +1,34 @@
+import { FlashcardState } from "@/types/flashcard";
+
+type FeedbackProps = {
+  state: FlashcardState;
+  translatedWord: string;
+};
+
+export function FeedbackMessage({ state, translatedWord }: FeedbackProps) {
+  switch (state) {
+    case "correct":
+      return (
+        <p className="text-green-600">
+          🎉 Bravo ! La bonne réponse était : <strong>{translatedWord}</strong>
+        </p>
+      );
+
+    case "help-shown":
+      return (
+        <p className="text-green-600">
+          La réponse est : <strong>{translatedWord}</strong>
+        </p>
+      );
+
+    case "incorrect":
+      return (
+        <p className="text-red-500">
+          ❌ Ce n'est pas la bonne réponse, réessaie !
+        </p>
+      );
+
+    default:
+      return null;
+  }
+}

--- a/src/components/card/LanguageCard.tsx
+++ b/src/components/card/LanguageCard.tsx
@@ -1,4 +1,3 @@
-"use client";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -14,16 +13,8 @@ export default function LanguageCard({
   href,
 }: LanguageCardProps) {
   return (
-    <Link
-      href={href}
-      className="language-card gap-6"
-    >
-      <Image
-        src={flagUrl}
-        alt={`${name} flag`}
-        width={150}
-        height={150}
-      />
+    <Link href={href} className="language-card gap-6">
+      <Image src={flagUrl} alt={`${name} flag`} width={150} height={150} />
       <p className="text-lg">{name}</p>
     </Link>
   );

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?:
     | "auth"
     | "primary"
@@ -8,6 +8,8 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
     | "delete"
     | "edit"
     | "cancel"
+    | "flashcardSeeAnswer"
+    | "flashcardRetryAnwser"
     | "save";
   className?: string;
 };
@@ -15,16 +17,21 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 export default function Button({
   children,
   variant = "primary",
+  disabled,
   className = "",
   ...props
 }: ButtonProps) {
-  const baseStyle = "p-2 cursor-pointer";
+  const baseStyle = "p-2";
 
   const variants = {
     auth: "border-2 uppercase text-sm w-38 rounded-md hover:bg-black hover:text-white",
     primary: "border-2 uppercase rounded-xl",
     submit:
       "border-2 bg-emerald-200 w-full uppercase rounded-xl hover:bg-emerald-300 ",
+    flashcardSeeAnswer:
+      "border-2 bg-orange-200 w-full uppercase rounded-xl hover:bg-orange-300 ",
+    flashcardRetryAnwser:
+      "border-2 bg-red-300 w-full uppercase rounded-xl hover:bg-red-400 ",
     option: "flex justify-center gap-2",
     icon: "border-2 rounded-xl flex flex-col items-center gap-12 min-w-60 p-8 text-white",
     delete:
@@ -35,10 +42,14 @@ export default function Button({
     save: "border-2 bg-emerald-200 w-38 uppercase rounded-xl hover:bg-emerald-300 hover:text-white",
   };
 
+  const disabledStyle = disabled
+    ? "opacity-50 bg-gray-300 hover:bg-gray-300 cursor-not-allowed"
+    : "cursor-pointer";
+
   return (
     <button
       type="button"
-      className={`${baseStyle} ${className} ${variants[variant]}`}
+      className={`${baseStyle} ${disabledStyle} ${className} ${variants[variant]}`}
       {...props}
     >
       {children}

--- a/src/components/ui/Title.tsx
+++ b/src/components/ui/Title.tsx
@@ -2,12 +2,13 @@ import { ReactNode } from "react";
 
 type TitleProps = {
   children: ReactNode;
-  variant?: "sm" | "lg" | "flashcard";
+  variant?: "sm" | "md" | "lg" | "flashcard";
 };
 
 export default function Title({ children, variant = "sm" }: TitleProps) {
   const variants = {
     sm: "text-3xl font-bold text-center",
+    md: "text-4xl font-bold text-center",
     lg: "text-5xl font-bold text-center",
     flashcard: "text-2xl text-center",
   };

--- a/src/hooks/useFlashcardSession.ts
+++ b/src/hooks/useFlashcardSession.ts
@@ -1,4 +1,5 @@
 import { TFlashcard } from "@/types/flashcard";
+import { useRouter } from "next/navigation";
 import { useState, useCallback, useMemo } from "react";
 
 export type FlashcardState =
@@ -10,8 +11,11 @@ export type FlashcardState =
 export function useFlashcardSession(
   flashcards: TFlashcard[],
   currentIndex: number,
-  setCurrentIndex: React.Dispatch<React.SetStateAction<number>>
+  setCurrentIndex: React.Dispatch<React.SetStateAction<number>>,
+  id: string
 ) {
+  const router = useRouter();
+
   const currentCard = useMemo(
     () => flashcards[currentIndex],
     [flashcards, currentIndex]
@@ -57,6 +61,10 @@ export function useFlashcardSession(
     setCurrentIndex((prev) => (prev + 1) % flashcards.length);
   }, [flashcards.length, setCurrentIndex]);
 
+  const handleFinish = () => {
+    router.push(`/language/${id}`);
+  };
+
   return {
     currentCard,
     answer,
@@ -66,5 +74,6 @@ export function useFlashcardSession(
     handleHelp,
     handleNext,
     handleReloadInput,
+    handleFinish,
   };
 }

--- a/src/hooks/useFlashcardSession.ts
+++ b/src/hooks/useFlashcardSession.ts
@@ -33,6 +33,9 @@ export function useFlashcardSession(
   };
 
   const handleCheckAnswer = () => {
+    if (!answer || !answer.trim()) {
+      return;
+    }
     const correct =
       answer.trim().toLowerCase() ===
       currentCard.translatedWord.trim().toLowerCase();

--- a/src/hooks/useFlashcardSession.ts
+++ b/src/hooks/useFlashcardSession.ts
@@ -1,0 +1,67 @@
+import { TFlashcard } from "@/types/flashcard";
+import { useState, useCallback, useMemo } from "react";
+
+export type FlashcardState =
+  | "answering"
+  | "correct"
+  | "incorrect"
+  | "help-shown";
+
+export function useFlashcardSession(
+  flashcards: TFlashcard[],
+  currentIndex: number,
+  setCurrentIndex: React.Dispatch<React.SetStateAction<number>>
+) {
+  const currentCard = useMemo(
+    () => flashcards[currentIndex],
+    [flashcards, currentIndex]
+  );
+
+  const [answer, setAnswer] = useState("");
+  const [state, setState] = useState<FlashcardState>("answering");
+
+  const handleAnswer = (value: string) => {
+    setAnswer(value);
+    if (state !== "answering") {
+      setState("answering");
+    }
+  };
+
+  const handleReloadInput = () => {
+    setAnswer("");
+    setState("answering");
+  };
+
+  const handleCheckAnswer = () => {
+    const correct =
+      answer.trim().toLowerCase() ===
+      currentCard.translatedWord.trim().toLowerCase();
+
+    if (correct) {
+      setState("correct");
+    } else {
+      setState("incorrect");
+    }
+  };
+
+  const handleHelp = () => {
+    setState("help-shown");
+  };
+
+  const handleNext = useCallback(() => {
+    setAnswer("");
+    setState("answering");
+    setCurrentIndex((prev) => (prev + 1) % flashcards.length);
+  }, [flashcards.length, setCurrentIndex]);
+
+  return {
+    currentCard,
+    answer,
+    state,
+    handleAnswer,
+    handleCheckAnswer,
+    handleHelp,
+    handleNext,
+    handleReloadInput,
+  };
+}

--- a/src/types/flashcard.ts
+++ b/src/types/flashcard.ts
@@ -12,4 +12,10 @@ export type TFlashcard = {
   knowledgeScore: number;
   createdAt: string;
   updatedAt: string;
-}
+};
+
+export type FlashcardState =
+  | "answering"
+  | "correct"
+  | "incorrect"
+  | "help-shown";


### PR DESCRIPTION
## Description

- Create Train Page for practicing flashcards
- Add a custom hook (useFlashcardSession) to centralize all flashcard logic
- Can be reused for both training and future test/exam mode

<img width="665" height="557" alt="Screenshot 2025-11-21 at 15 08 24" src="https://github.com/user-attachments/assets/c3195f2e-724f-4b9d-a75d-f6f692dc0226" />
<img width="665" height="557" alt="Screenshot 2025-11-21 at 15 08 32" src="https://github.com/user-attachments/assets/fb1e0cb3-2de2-4059-9045-c89b21ca9c2d" />
<img width="665" height="557" alt="Screenshot 2025-11-21 at 15 08 40" src="https://github.com/user-attachments/assets/d8f3e970-522d-4b5a-898a-81c988284d3e" />
<img width="665" height="557" alt="Screenshot 2025-11-21 at 15 09 16" src="https://github.com/user-attachments/assets/9684bb2b-b28f-49fc-a820-30b1ac3159ef" />


