### PR TITLE
feat(show-example-sentence): add example sentence in training session and modify naming of reveal answer state

### DIFF
--- a/src/components/card/Flashcard.tsx
+++ b/src/components/card/Flashcard.tsx
@@ -33,7 +33,7 @@ export default function Flashcard({
     state,
     handleAnswer,
     handleCheckAnswer,
-    handleHelp,
+    handleRevealAnswer,
     handleNext,
     handleReloadInput,
     handleFinish,
@@ -42,15 +42,15 @@ export default function Flashcard({
   const buttonsConfig: ButtonConfig[] = [
     {
       states: ["answering"],
-      label: "Vérifier la réponse",
-      variant: "submit",
-      onClick: handleCheckAnswer,
+      label: "Voir la réponse",
+      variant: "flashcardSeeAnswer",
+      onClick: handleRevealAnswer,
     },
     {
       states: ["answering"],
-      label: "Voir la réponse",
-      variant: "flashcardSeeAnswer",
-      onClick: handleHelp,
+      label: "Vérifier la réponse",
+      variant: "submit",
+      onClick: handleCheckAnswer,
     },
     {
       states: ["incorrect"],
@@ -59,7 +59,7 @@ export default function Flashcard({
       onClick: handleReloadInput,
     },
     {
-      states: ["correct", "help-shown"],
+      states: ["correct", "answer-revealed"],
       label:
         currentIndex === flashcards.length - 1
           ? "Terminer la session"
@@ -111,6 +111,7 @@ export default function Flashcard({
         <FeedbackMessage
           state={state}
           translatedWord={currentCard.translatedWord}
+          exampleSentence={currentCard.exampleSentence}
         />
       </div>
       <div className="flex gap-4 justify-center w-full">{renderedButtons}</div>

--- a/src/components/card/Flashcard.tsx
+++ b/src/components/card/Flashcard.tsx
@@ -2,7 +2,7 @@ import { Button, Input } from "@/ui";
 import { useFlashcardSession } from "@/hooks/useFlashcardSession";
 import { TFlashcard } from "@/types/flashcard";
 import { ButtonProps } from "../ui/Button";
-import { FeedbackMessage } from "./FlashcardMessage";
+import { FlashcardMessage } from "./FlashcardMessage";
 import Image from "next/image";
 
 type FlashcardProps = {
@@ -108,7 +108,7 @@ export default function Flashcard({
             />
           </>
         )}
-        <FeedbackMessage
+        <FlashcardMessage
           state={state}
           translatedWord={currentCard.translatedWord}
           exampleSentence={currentCard.exampleSentence}

--- a/src/components/card/FlashcardMessage.tsx
+++ b/src/components/card/FlashcardMessage.tsx
@@ -3,22 +3,39 @@ import { FlashcardState } from "@/types/flashcard";
 type FeedbackProps = {
   state: FlashcardState;
   translatedWord: string;
+  exampleSentence?: string;
 };
 
-export function FeedbackMessage({ state, translatedWord }: FeedbackProps) {
+function ExampleSentence({ sentence }: { sentence?: string }) {
+  if (!sentence) return null;
+  return <p className="text-gray-600 italic">Exemple : {sentence}</p>;
+}
+
+export function FeedbackMessage({
+  state,
+  translatedWord,
+  exampleSentence,
+}: FeedbackProps) {
   switch (state) {
     case "correct":
       return (
-        <p className="text-green-600">
-          🎉 Bravo ! La bonne réponse était : <strong>{translatedWord}</strong>
-        </p>
+        <div className="flex flex-col gap-4">
+          <p className="text-green-600">
+            🎉 Bravo ! La bonne réponse était :{" "}
+            <strong>{translatedWord}</strong>
+          </p>
+          <ExampleSentence sentence={exampleSentence} />
+        </div>
       );
 
-    case "help-shown":
+    case "answer-revealed":
       return (
-        <p className="text-green-600">
-          La réponse est : <strong>{translatedWord}</strong>
-        </p>
+        <div className="flex flex-col gap-4">
+          <p className="text-green-600">
+            La réponse est : <strong>{translatedWord}</strong>
+          </p>
+          <ExampleSentence sentence={exampleSentence} />
+        </div>
       );
 
     case "incorrect":

--- a/src/components/card/FlashcardMessage.tsx
+++ b/src/components/card/FlashcardMessage.tsx
@@ -11,7 +11,7 @@ function ExampleSentence({ sentence }: { sentence?: string }) {
   return <p className="text-gray-600 italic">Exemple : {sentence}</p>;
 }
 
-export function FeedbackMessage({
+export function FlashcardMessage({
   state,
   translatedWord,
   exampleSentence,

--- a/src/hooks/useFlashcardSession.ts
+++ b/src/hooks/useFlashcardSession.ts
@@ -1,12 +1,6 @@
-import { TFlashcard } from "@/types/flashcard";
+import { TFlashcard, FlashcardState } from "@/types/flashcard";
 import { useRouter } from "next/navigation";
 import { useState, useCallback, useMemo } from "react";
-
-export type FlashcardState =
-  | "answering"
-  | "correct"
-  | "incorrect"
-  | "help-shown";
 
 export function useFlashcardSession(
   flashcards: TFlashcard[],
@@ -51,8 +45,8 @@ export function useFlashcardSession(
     }
   };
 
-  const handleHelp = () => {
-    setState("help-shown");
+  const handleRevealAnswer = () => {
+    setState("answer-revealed");
   };
 
   const handleNext = useCallback(() => {
@@ -71,7 +65,7 @@ export function useFlashcardSession(
     state,
     handleAnswer,
     handleCheckAnswer,
-    handleHelp,
+    handleRevealAnswer,
     handleNext,
     handleReloadInput,
     handleFinish,

--- a/src/types/flashcard.ts
+++ b/src/types/flashcard.ts
@@ -18,4 +18,4 @@ export type FlashcardState =
   | "answering"
   | "correct"
   | "incorrect"
-  | "help-shown";
+  | "answer-revealed";


### PR DESCRIPTION
## Description 

- I added the example sentence to the flashcard, displayed after the user submits the correct answer or chooses to reveal it.

- I updated the naming of the “reveal answer” state, as we will need a separate “help” naming in the future.

- I changed the order of the buttons (“See Answer” and “Verify Answer”) for a better user experience.

<img width="573" height="395" alt="Screenshot 2026-01-05 at 15 39 53" src="https://github.com/user-attachments/assets/5eb3b40e-e624-4b00-bfbd-28f197a7651c" />
<img width="573" height="395" alt="Screenshot 2026-01-05 at 15 40 20" src="https://github.com/user-attachments/assets/aefd9cd6-ff51-4592-9690-b8c8166dbadb" />
<img width="573" height="395" alt="Screenshot 2026-01-05 at 15 40 27" src="https://github.com/user-attachments/assets/9bf9619f-a656-471e-925f-8b3d08db9827" />
<img width="573" height="395" alt="Screenshot 2026-01-05 at 15 58 22" src="https://github.com/user-attachments/assets/352333c1-89d2-4a85-8e7d-17e696362481" />

